### PR TITLE
Refactor

### DIFF
--- a/frontend/src/components/ServerControls/ServerControls.js
+++ b/frontend/src/components/ServerControls/ServerControls.js
@@ -36,10 +36,15 @@ function ServerControls() {
           .catch(err => console.log)
     }
 
+    const stopServer = () => {
+      api.get('/server/stop')
+        .catch(err => console.log)
+  }
+
     return (
         <div>
             <ColorButton className="control-btn" variant="contained" onClick={() => startServer()}>Start</ColorButton>
-            <ColorButton className="control-btn" variant="contained" style={{backgroundColor: red[700]}} onClick={() => killServer()}>Stop</ColorButton>
+            <ColorButton className="control-btn" variant="contained" style={{backgroundColor: red[700]}} onClick={() => stopServer()}>Stop</ColorButton>
             <ColorButton className="control-btn" variant="contained" style={{backgroundColor: red[900]}} onClick={() => killServer()}>Kill</ColorButton>
         </div>
     )

--- a/frontend/src/pages/HomeDashboard/HomeDashboard.js
+++ b/frontend/src/pages/HomeDashboard/HomeDashboard.js
@@ -7,8 +7,6 @@ import useStore from '../../store';
 function HomeDashboard(){
     const [serverState, setServerState] = useState("Stopped");
 
-    
-
     const handleServerState = (state) => {
         switch(state){
             case "SERVER_STARTING":
@@ -39,11 +37,6 @@ function HomeDashboard(){
         })
       }, []);
 
-
-    //subscribe to minecraft server state updates 
-
-  
-    
     return (
         <div>
             <h1>{serverState}</h1>


### PR DESCRIPTION
Create a stop endpoint that gracefully shuts down the Minecraft server. Also fixed a memory leak due to an issue when unsubscribing from the server state on the home page (needed to subscribe **and** unsubscribe in the useEffect). Also fixed various other bugs  